### PR TITLE
Fix PyQuil 4.0 deprecation warning in pyquil_to_circuit()

### DIFF
--- a/quantumflow/xforest.py
+++ b/quantumflow/xforest.py
@@ -121,7 +121,7 @@ def pyquil_to_circuit(program: "pqProgram") -> Circuit:
         elif isinstance(inst, pqGate):
             name = QUIL_TO_QF[inst.name]
             defgate = STDGATES[name]
-            qubits = [q.index for q in inst.qubits] # type: ignore
+            qubits = inst.get_qubit_indices()
             gate = defgate(*chain((np.real(p) for p in inst.params), qubits))  # type: ignore
             circ += gate
         else:


### PR DESCRIPTION
## Summary
- Replace deprecated `.qubits` property access with `get_qubit_indices()` 
- Eliminates 19 deprecation warnings during test runs (56 → 37 warnings)

Closes #16

## Test plan
- [x] All 1332 tests pass
- [x] xforest_test.py passes without deprecation warnings