### PR TITLE
Improve transpile.py test coverage from 7% to 92%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,11 @@ ignore = []
 
 [tool.pytest.ini_options]
 testpaths = ["quantumflow", "examples"]
+filterwarnings = [
+    # pyquil's .qubits property internally calls deprecated get_qubits()
+    # This is a bug in pyquil, not our code. See: https://github.com/rigetti/pyquil/issues/1720
+    "ignore:Call to deprecated method get_qubits:DeprecationWarning",
+]
 
 
 

--- a/quantumflow/transpile_test.py
+++ b/quantumflow/transpile_test.py
@@ -6,58 +6,110 @@
 import pytest
 
 import quantumflow as qf
+from quantumflow.transpile import _guess_format, transpile, TRANSPILE_FORMATS
+
+# Check which optional dependencies are available
+pyquil = pytest.importorskip("pyquil", reason="pyquil not installed")
+braket = pytest.importorskip("braket", reason="braket not installed")
+cirq = pytest.importorskip("cirq", reason="cirq not installed")
+qiskit = pytest.importorskip("qiskit", reason="qiskit not installed")
+qutip_qip = pytest.importorskip("qutip_qip", reason="qutip-qip not installed")
+
+# qsimcirq is optional - some tests will skip if not available
+try:
+    import qsimcirq
+    HAS_QSIM = True
+except ImportError:
+    HAS_QSIM = False
+
 from quantumflow import xbraket, xcirq, xforest, xqiskit, xqutip
-from quantumflow.transpile import _guess_format, transpile
-
-pytest.importorskip("pyquil")  # noqa: 402
-pytest.importorskip("qsimcirq")  # noqa: 402
-pytest.importorskip("braket")  # noqa: 402
-pytest.importorskip("cirq")  # noqa: 402
-pytest.importorskip("qiskit")  # noqa: 402
 
 
-def test_guess_format() -> None:
+def test_transpile_formats_constant() -> None:
+    """Test that TRANSPILE_FORMATS contains expected formats."""
+    assert "quantumflow" in TRANSPILE_FORMATS
+    assert "cirq" in TRANSPILE_FORMATS
+    assert "qiskit" in TRANSPILE_FORMATS
+    assert "braket" in TRANSPILE_FORMATS
+    assert "pyquil" in TRANSPILE_FORMATS
+    assert "qasm" in TRANSPILE_FORMATS
+    assert "quirk" in TRANSPILE_FORMATS
+    assert "qsim" in TRANSPILE_FORMATS
+    assert "qutip" in TRANSPILE_FORMATS
+
+
+def test_guess_format_quantumflow() -> None:
+    """Test format detection for QuantumFlow circuits."""
     circ = qf.Circuit(qf.X(0), qf.Z(1))
+    assert _guess_format(circ) == "quantumflow"
 
+
+def test_guess_format_cirq() -> None:
+    """Test format detection for Cirq circuits."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
     c0 = xcirq.circuit_to_cirq(circ)
-    f0 = _guess_format(c0)
-    assert f0 == "cirq"
+    assert _guess_format(c0) == "cirq"
 
+
+def test_guess_format_braket() -> None:
+    """Test format detection for Braket circuits."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
     c1 = xbraket.circuit_to_braket(circ)
-    f1 = _guess_format(c1)
-    assert f1 == "braket"
+    assert _guess_format(c1) == "braket"
 
+
+def test_guess_format_pyquil() -> None:
+    """Test format detection for PyQuil programs."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
     c2 = xforest.circuit_to_pyquil(circ)
-    f2 = _guess_format(c2)
-    assert f2 == "pyquil"
+    assert _guess_format(c2) == "pyquil"
 
+
+def test_guess_format_qiskit() -> None:
+    """Test format detection for Qiskit circuits."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
     c3 = xqiskit.circuit_to_qiskit(circ)
-    f3 = _guess_format(c3)
-    assert f3 == "qiskit"
+    assert _guess_format(c3) == "qiskit"
 
+
+def test_guess_format_qasm() -> None:
+    """Test format detection for QASM strings."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
     c4 = xqiskit.circuit_to_qasm(circ)
-    f4 = _guess_format(c4)
-    assert f4 == "qasm"
-
-    c4 = xqutip.circuit_to_qutip(circ)
-    f4 = _guess_format(c4)
-    assert f4 == "qutip"
+    assert _guess_format(c4) == "qasm"
 
 
-circuit_formats = [
+def test_guess_format_qutip() -> None:
+    """Test format detection for QuTiP circuits."""
+    circ = qf.Circuit(qf.X(0), qf.Z(1))
+    c5 = xqutip.circuit_to_qutip(circ)
+    assert _guess_format(c5) == "qutip"
+
+
+def test_guess_format_unknown() -> None:
+    """Test that unknown formats raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown source format"):
+        _guess_format(12345)
+
+    with pytest.raises(ValueError, match="Unknown source format"):
+        _guess_format({"not": "a circuit"})
+
+
+# Formats that don't require qsim
+circuit_formats_no_qsim = [
     "quantumflow",
     "cirq",
     "braket",
     "pyquil",
     "qiskit",
     "qasm",
-    "qsim",
     "qutip",
 ]
 
 
-@pytest.mark.parametrize("circuit_format", circuit_formats)
-def test_transpile(circuit_format: str) -> None:
+@pytest.mark.parametrize("circuit_format", circuit_formats_no_qsim)
+def test_transpile_roundtrip(circuit_format: str) -> None:
+    """Test roundtrip transpilation for each format."""
     circ0 = qf.Circuit(qf.X(0), qf.Z(1))
 
     circ1 = transpile(circ0, output_format=circuit_format)
@@ -65,8 +117,9 @@ def test_transpile(circuit_format: str) -> None:
     assert qf.circuits_close(circ0, circ2)
 
 
-@pytest.mark.parametrize("circuit_format", circuit_formats)
-def test_transpile_translate(circuit_format: str) -> None:
+@pytest.mark.parametrize("circuit_format", circuit_formats_no_qsim)
+def test_transpile_with_translation(circuit_format: str) -> None:
+    """Test transpilation with gate translation for complex gates."""
     circ0 = qf.Circuit(
         qf.X(0), qf.Z(1), qf.Margolus(0, 1, 2), qf.Can(0.1, 0.2, 0.3, 2, 3)
     )
@@ -76,29 +129,86 @@ def test_transpile_translate(circuit_format: str) -> None:
     assert qf.circuits_close(circ0, circ2)
 
 
-def test_transpile_quirk() -> None:
+@pytest.mark.skipif(not HAS_QSIM, reason="qsimcirq not installed")
+def test_transpile_qsim() -> None:
+    """Test transpilation to qsim format."""
     circ0 = qf.Circuit(qf.X(0), qf.Z(1))
-    _ = transpile(circ0, output_format="quirk")
+    circ1 = transpile(circ0, output_format="qsim")
+    circ2 = transpile(circ1, output_format="quantumflow")
+    assert qf.circuits_close(circ0, circ2)
 
 
-def test_transpile_accross() -> None:
-    """Transpile to each supported format in turn, then back to QF"""
+@pytest.mark.skipif(not HAS_QSIM, reason="qsimcirq not installed")
+def test_transpile_qsim_with_translation() -> None:
+    """Test transpilation to qsim with complex gates."""
+    circ0 = qf.Circuit(
+        qf.X(0), qf.Z(1), qf.Margolus(0, 1, 2), qf.Can(0.1, 0.2, 0.3, 2, 3)
+    )
+    circ1 = transpile(circ0, output_format="qsim")
+    circ2 = transpile(circ1, output_format="quantumflow")
+    assert qf.circuits_close(circ0, circ2)
 
+
+def test_transpile_quirk() -> None:
+    """Test transpilation to Quirk format (output only)."""
+    circ0 = qf.Circuit(qf.X(0), qf.Z(1))
+    result = transpile(circ0, output_format="quirk")
+    # Quirk output is a JSON string
+    assert isinstance(result, str)
+    assert "cols" in result  # Quirk JSON has 'cols' key
+
+
+def test_transpile_across_formats() -> None:
+    """Transpile to each supported format in turn, then back to QF."""
     circ0 = qf.Circuit(qf.Margolus(0, 1, 2))
 
     circ1 = circ0
-    for f0 in circuit_formats:
+    for f0 in circuit_formats_no_qsim:
         circ1 = transpile(circ0, output_format=f0)
 
     circ2 = transpile(circ1)
     assert qf.circuits_close(circ0, circ2)
-    print(circ2)
 
 
-def test_transpile_errors() -> None:
-    with pytest.raises(ValueError):
-        _ = transpile(19939848)
+def test_transpile_unknown_input() -> None:
+    """Test that unknown input types raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown source format"):
+        transpile(19939848)
 
+
+def test_transpile_unknown_output_format() -> None:
+    """Test that unknown output format raises ValueError."""
     circ0 = qf.Circuit(qf.Margolus(0, 1, 2))
-    with pytest.raises(ValueError):
-        _ = transpile(circ0, output_format="NOT_A_FORMAT")
+    with pytest.raises(ValueError, match="Unknown output format"):
+        transpile(circ0, output_format="NOT_A_FORMAT")
+
+
+def test_transpile_empty_circuit() -> None:
+    """Test transpilation of empty circuits."""
+    circ0 = qf.Circuit()
+    # Note: qutip doesn't handle empty circuits (max() on empty qubits fails)
+    formats_for_empty = [f for f in circuit_formats_no_qsim if f != "qutip"]
+    for fmt in formats_for_empty:
+        circ1 = transpile(circ0, output_format=fmt)
+        circ2 = transpile(circ1, output_format="quantumflow")
+        assert len(circ2) == 0
+
+
+def test_transpile_single_qubit() -> None:
+    """Test transpilation of single-qubit circuits."""
+    circ0 = qf.Circuit(qf.H(0), qf.T(0), qf.S(0))
+    for fmt in circuit_formats_no_qsim:
+        circ1 = transpile(circ0, output_format=fmt)
+        circ2 = transpile(circ1, output_format="quantumflow")
+        assert qf.circuits_close(circ0, circ2)
+
+
+def test_transpile_default_output() -> None:
+    """Test that default output format is quantumflow."""
+    circ0 = qf.Circuit(qf.X(0), qf.Z(1))
+    qk_circ = xqiskit.circuit_to_qiskit(circ0)
+
+    # transpile with default should return quantumflow Circuit
+    result = transpile(qk_circ)
+    assert isinstance(result, qf.Circuit)
+    assert qf.circuits_close(circ0, result)


### PR DESCRIPTION
## Summary
- Restructure tests so they run when qsimcirq is unavailable (was skipping entire module)
- Add individual tests for each format detection
- Add edge case tests (empty circuits, single qubit, default output)
- Add error handling tests (unknown input/output formats)
- Suppress pyquil internal deprecation warning (upstream bug: [rigetti/pyquil#1720](https://github.com/rigetti/pyquil/issues/1720))

**Coverage:** 7% → 92%  
**Test count:** 1332 → 1362 (+30 new tests)

Closes #9

## Test plan
- [x] All 1362 tests pass
- [x] Coverage verified with pytest-cov
- [x] Pyquil warnings suppressed with comment linking to upstream issue