### PR TITLE
Replace assert statements with proper exceptions

### DIFF
--- a/quantumflow/gradients.py
+++ b/quantumflow/gradients.py
@@ -110,7 +110,7 @@ def expectation_gradients(
     expectation = tensors.inner(forward.tensor, back.tensor)
 
     for elem in circ:
-        assert isinstance(elem, Gate)
+        assert isinstance(elem, Gate)  # Checked by circ.H above
         back = elem.run(back)
         forward = elem.run(forward)
 
@@ -157,7 +157,7 @@ def state_fidelity_gradients(
     ol = tensors.inner(forward.tensor, back.tensor)
 
     for elem in circ:
-        assert isinstance(elem, Gate)
+        assert isinstance(elem, Gate)  # Checked by circ.H above
         back = elem.run(back)
         forward = elem.run(forward)
 
@@ -229,7 +229,8 @@ def parameter_shift_circuits(
     """
 
     elem = circ[index]
-    assert isinstance(elem, Gate)
+    if not isinstance(elem, Gate):
+        raise TypeError(f"Gradient computation requires Gate operations, got {type(elem).__name__}")
     gate_type = type(elem)
     if gate_type not in shift_constant:
         raise ValueError(_UNDIFFERENTIABLE_GATE_MSG)

--- a/quantumflow/gradients_test.py
+++ b/quantumflow/gradients_test.py
@@ -83,6 +83,16 @@ def test_gradient_errors() -> None:
         qf.expectation_gradients(ket0, circ, qf.IdentityGate([0, 1]))
 
 
+def test_gradient_non_gate_error() -> None:
+    """Test that parameter_shift_circuits raises TypeError for non-Gate operations."""
+    # Note: state_fidelity_gradients and expectation_gradients call circ.H first,
+    # which fails earlier with ValueError for non-Gate ops. Only parameter_shift_circuits
+    # can actually reach our TypeError check.
+    circ = qf.Circuit([qf.Measure(0)])
+    with pytest.raises(TypeError, match="requires Gate operations"):
+        qf.parameter_shift_circuits(circ, 0)
+
+
 def test_parameter_shift_circuits() -> None:
     """Checks that gradients calculated with middle out algorithm
     match gradients calculated from parameter shift rule.

--- a/quantumflow/paulialgebra.py
+++ b/quantumflow/paulialgebra.py
@@ -550,8 +550,8 @@ def pauli_decompose_hermitian(
 
     if qubits is None:
         qubits = list(range(N))
-    else:
-        assert len(qubits) == N
+    elif len(qubits) != N:
+        raise ValueError(f"Number of qubits ({len(qubits)}) must match matrix size ({N})")
 
     terms = []
     for ops in product("IXYZ", repeat=N):

--- a/quantumflow/paulialgebra_test.py
+++ b/quantumflow/paulialgebra_test.py
@@ -343,6 +343,11 @@ def test_pauli_decompose_hermitian() -> None:
     with pytest.raises(ValueError):
         qf.pauli_decompose_hermitian(op)
 
+    # Test qubit count mismatch
+    op = np.ones(shape=[4, 4])
+    with pytest.raises(ValueError, match="Number of qubits"):
+        qf.pauli_decompose_hermitian(op, qubits=[0, 1, 2])  # 3 qubits for 2-qubit matrix
+
 
 def test_pauli_rewire() -> None:
     term = sZ(0) * sX(1)

--- a/quantumflow/tensors.py
+++ b/quantumflow/tensors.py
@@ -181,7 +181,8 @@ def tensormul(
 ) -> QubitTensor:
     N = np.ndim(tensor1)
     K = np.ndim(tensor0) // 2
-    assert K == len(indices)
+    if K != len(indices):
+        raise ValueError(f"Gate dimension ({K}) must match number of indices ({len(indices)})")
 
     gate = np.reshape(tensor0, [2**K, 2**K])
 
@@ -208,7 +209,8 @@ def tensormul_diagonal(
 ) -> QubitTensor:
     N = np.ndim(tensor1)
     K = np.ndim(tensor0_diagonal)
-    assert K == len(indices)
+    if K != len(indices):
+        raise ValueError(f"Diagonal dimension ({K}) must match number of indices ({len(indices)})")
 
     perm = list(indices) + [n for n in range(N) if n not in indices]
     inv_perm = np.argsort(perm)

--- a/quantumflow/tensors_test.py
+++ b/quantumflow/tensors_test.py
@@ -68,4 +68,25 @@ def test_inner_product() -> None:
         tensors.inner(qf.CNot(0, 1).tensor, qf.X(0).tensor)
 
 
+def test_tensormul_dimension_mismatch() -> None:
+    """Test that tensormul raises ValueError for dimension mismatch."""
+    state = qf.zero_state(3).tensor
+    gate = qf.CNot(0, 1).tensor  # 2-qubit gate
+
+    # Provide wrong number of indices (3 indices for 2-qubit gate)
+    with pytest.raises(ValueError, match="Gate dimension"):
+        tensors.tensormul(gate, state, (0, 1, 2))
+
+
+def test_tensormul_diagonal_dimension_mismatch() -> None:
+    """Test that tensormul_diagonal raises ValueError for dimension mismatch."""
+    state = qf.zero_state(3).tensor
+    diagonal = np.array([1, 1, 1, 1])  # 2-qubit diagonal
+    diagonal = diagonal.reshape((2, 2))
+
+    # Provide wrong number of indices (3 indices for 2-qubit diagonal)
+    with pytest.raises(ValueError, match="Diagonal dimension"):
+        tensors.tensormul_diagonal(diagonal, state, (0, 1, 2))
+
+
 # fin

--- a/quantumflow/visualization.py
+++ b/quantumflow/visualization.py
@@ -170,7 +170,8 @@ def circuit_to_latex(
             (https://arxiv.org/abs/1809.03842).
     """
 
-    assert package in ["qcircuit", "quantikz"]  # FIXME. Throw Exception
+    if package not in ["qcircuit", "quantikz"]:
+        raise ValueError(f"Unknown LaTeX package: {package}. Must be 'qcircuit' or 'quantikz'.")
 
     # TODO: I would be good to move much of the gate dependent details
     # into the gate classes, as has been done for circuit_to_diagram.

--- a/quantumflow/visualization_test.py
+++ b/quantumflow/visualization_test.py
@@ -35,6 +35,12 @@ def test_circuit_to_latex_error() -> None:
         qf.circuit_to_latex(circ)
 
 
+def test_circuit_to_latex_invalid_package() -> None:
+    circ = qf.Circuit([qf.H(0)])
+    with pytest.raises(ValueError, match="Unknown LaTeX package"):
+        qf.circuit_to_latex(circ, package="invalid_package")
+
+
 def test_visualize_circuit() -> None:
     circ = qf.Circuit()
 


### PR DESCRIPTION
## Summary

Replace `assert` statements with proper exceptions for **user input validation**.

### Changes

| File | Change |
|------|--------|
| visualization.py:173 | `assert` → `ValueError` for invalid package parameter |
| paulialgebra.py:554 | `assert` → `ValueError` for qubit count mismatch |
| tensors.py:184,211 | `assert` → `ValueError` for dimension mismatches |
| gradients.py:232 | `assert` → `TypeError` for non-Gate in parameter_shift_circuits |

### Not Changed (asserts are appropriate)

| File | Reason |
|------|--------|
| gradients.py:113,160 | Unreachable - `circ.H` validates Gates first |
| decompositions.py:429,664 | Internal algorithm invariants, not user input |

All exceptions include descriptive error messages. Tests added for all new exception paths.

Closes #2, #3, #4, #5

## Test plan
- [x] All 1366 tests pass (+4 new tests)
- [x] Verified exceptions work correctly with `python -O`