### PR TITLE
Add UnitaryGate support to Braket integration

### DIFF
--- a/quantumflow/xbraket_test.py
+++ b/quantumflow/xbraket_test.py
@@ -41,6 +41,101 @@ def test_circuit_to_qiskit() -> None:
     print(bkcirc)
 
 
+def test_braket_unitary_roundtrip_2qubit() -> None:
+    """Test round-trip conversion of 2-qubit UnitaryGate through Braket."""
+    # Use RandomGate which is a UnitaryGate subclass
+    gate0 = qf.RandomGate([0, 1])
+    circ0 = qf.Circuit([gate0])
+
+    # Convert QF → Braket → QF
+    bkcirc = circuit_to_braket(circ0)
+    circ1 = braket_to_circuit(bkcirc)
+
+    assert qf.circuits_close(circ0, circ1)
+
+
+def test_braket_unitary_roundtrip_1qubit() -> None:
+    """Test round-trip conversion of 1-qubit UnitaryGate through Braket."""
+    gate0 = qf.RandomGate([0])
+    circ0 = qf.Circuit([gate0])
+
+    # Convert QF → Braket → QF
+    bkcirc = circuit_to_braket(circ0)
+    circ1 = braket_to_circuit(bkcirc)
+
+    assert qf.circuits_close(circ0, circ1)
+
+
+def test_braket_unitary_single_qubit() -> None:
+    """Test Braket Unitary gate conversion for single qubit."""
+    from braket.circuits import Circuit as bkCircuit
+
+    # Create Braket circuit with unitary (X gate as matrix)
+    bkcirc = bkCircuit()
+    U = np.array([[0, 1], [1, 0]])
+    bkcirc = bkcirc.unitary(matrix=U, targets=[0])
+
+    # Convert to QuantumFlow
+    circ = braket_to_circuit(bkcirc)
+
+    # Verify it's equivalent to X gate
+    assert qf.gates_close(circ[0], qf.X(0))
+
+
+def test_braket_unitary_2qubit_cnot() -> None:
+    """Test Braket 2-qubit Unitary gate conversion (CNOT matrix)."""
+    from braket.circuits import Circuit as bkCircuit
+
+    # CNOT matrix
+    cnot_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 1],
+        [0, 0, 1, 0]
+    ])
+    bkcirc = bkCircuit()
+    bkcirc = bkcirc.unitary(matrix=cnot_matrix, targets=[0, 1])
+
+    # Convert to QuantumFlow
+    circ = braket_to_circuit(bkcirc)
+
+    # Verify it's equivalent to CNOT gate
+    assert qf.gates_close(circ[0], qf.CNot(0, 1))
+
+
+def test_braket_unitary_mixed_circuit() -> None:
+    """Test circuit with both standard gates and UnitaryGate."""
+    from braket.circuits import Circuit as bkCircuit
+
+    # Create QF circuit with mixed gates
+    circ0 = qf.Circuit()
+    circ0 += qf.H(0)
+    circ0 += qf.RandomGate([1])  # UnitaryGate
+    circ0 += qf.CNot(0, 1)
+
+    # Convert QF → Braket → QF
+    bkcirc = circuit_to_braket(circ0)
+    circ1 = braket_to_circuit(bkcirc)
+
+    assert qf.circuits_close(circ0, circ1)
+
+
+def test_braket_unitary_complex_phase() -> None:
+    """Test Unitary with complex phases (S gate = phase gate)."""
+    from braket.circuits import Circuit as bkCircuit
+
+    # S gate matrix (has complex entries)
+    s_matrix = np.array([[1, 0], [0, 1j]])
+    bkcirc = bkCircuit()
+    bkcirc = bkcirc.unitary(matrix=s_matrix, targets=[0])
+
+    # Convert to QuantumFlow
+    circ = braket_to_circuit(bkcirc)
+
+    # Verify it's equivalent to S gate
+    assert qf.gates_close(circ[0], qf.S(0))
+
+
 def test_braketsimulator() -> None:
     circ = qf.Circuit()
     circ += qf.Rx(0.4, 0)


### PR DESCRIPTION
## Summary
- Adds bidirectional conversion support for arbitrary unitary matrix gates between QuantumFlow and AWS Braket
- `braket_to_circuit()`: Handles Braket Unitary gates by extracting matrix and creating QuantumFlow UnitaryGate
- `circuit_to_braket()`: Handles UnitaryGate by extracting matrix and calling `bkcircuit.unitary()`
- Follows the same pattern as xcirq.py MatrixGate handling

## Test plan
- [x] `test_braket_unitary_roundtrip`: Round-trip conversion with RandomGate
- [x] `test_braket_unitary_single_qubit`: Verify matrix equivalence
- [x] All 1376 tests pass

Closes #8